### PR TITLE
Document `metadata.annotations`

### DIFF
--- a/using.html.md.erb
+++ b/using.html.md.erb
@@ -245,9 +245,25 @@ These configurations are listed in the table below.
     </tr>
     <tr>
       <td>
+        <code>metadata.annotations</code>
+      </td>
+      <td>
+        Annotations to be added to every child resource, such as StatefulSet and Service.
+        Annotations containing <code>kubernetes.io</code> and <code>k8s.io</code> are ignored because these are reserved for Kubernetes core components.
+        When <code>spec.service.annotations</code> is specified, annotations for ingress will be merged between <code>spec.service.annotations</code> and
+        <code>metadata.annotations</code>
+        If the same key is specified in both configurations, value from <code>spec.service.annotations</code> will be applied.
+        Modifying annotations triggers a rolling restart of the StatefulSet.
+      </td>
+    </tr>
+    <tr>
+      <td>
         <code>spec.service.annotations</code>
       </td>
-      <td>Annotations on the ingress service</td>
+      <td>
+      Annotations on the ingress service
+      Annotations containing <code>kubernetes.io</code> and <code>k8s.io</code> are ignored because these are reserved for Kubernetes core components.
+      </td>
     </tr>
     <tr>
       <td>


### PR DESCRIPTION
[#169948271]

Co-authored-by: Aarti Kriplani <akriplani@pivotal.io>

## Changes:
This documents a new added field `metadata.annotations`


### Should this be merged to any or all of the current released branches (i.e., for 0.5 &/or 0.4)?
No. This change should stay on master. It will not be release to `0.5` or `0.4`. It will be included in `0.6`.
