### PR TITLE
Improved tarball extraction procedure

### DIFF
--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -96,8 +96,9 @@ To move the images:
 1. Load the images to your local Docker by running the following commands:
 
     ```bash
-    tar xvf PATH-TO-RABBITMQ-FOR-KUBERNETES-$version.tar
-    cd rabbitmq-for-kubernetes-$version
+    mkdir rabbitmq-for-kubernetes-${version}
+    tar -C rabbitmq-for-kubernetes-${version} -xf rabbitmq-for-kubernetes-${version}.tar
+    cd rabbitmq-for-kubernetes-${version}
     docker load -i images/rabbitmq-for-kubernetes-operator
     docker load -i images/rabbitmq
     docker load -i images/rabbitmq-for-kubernetes-servicebroker


### PR DESCRIPTION
Now all the commands can be just copy-pasted.

Please also backport to 0.5

## Changes:



### Should this be merged to any or all of the current released branches (i.e., for 0.5 &/or 0.4)?
