### PR TITLE
Document default values

### DIFF
--- a/using.html.md.erb
+++ b/using.html.md.erb
@@ -220,8 +220,8 @@ spec:
 **Description:** Specify the persistence settings for the RabbitmqCluster Service.
 The available settings are:
 
-* `storageClassName` -- the name of the Kubernetes StorageClass to use
-* `storage` -- the capacity of the persistent volume, expressed as a Kubernetes resource quantity
+* `storageClassName`: the name of the Kubernetes StorageClass to use
+* `storage`: the capacity of the persistent volume, expressed as a Kubernetes resource quantity
 
 **Default Values:**
 

--- a/using.html.md.erb
+++ b/using.html.md.erb
@@ -89,14 +89,14 @@ in which the `RabbitmqCluster` was defined.
 1. Check that the process was successful by running:
 
     ```
-    kubectl get all -l app=definition
+    kubectl get all -l app.kubernetes.io/name=definition
     ```
 
     If successful, you see a running Pod and a service that exposes the instance.<br><br>
 
     For example:
     <pre class="terminal">
-    $ kubectl get all -l app=definition
+    $ kubectl get all -l app.kubernetes.io/name=definition
     NAME                               READY   STATUS    RESTARTS   AGE
     pod/definition-rabbitmq-server-0   1/1     Running   0          112s
 
@@ -225,7 +225,7 @@ The available settings are:
 
 **Default Values:**
 
-* `storageClassName`: The default `StorageClass` for the Kubernetes cluster
+* `storageClassName`: Not set by default. By not setting a value, the default `StorageClass` for the Kubernetes cluster gets used
 * `storage`: 10Gi
 
 To see the default `StorageClass`, run `kubectl get storageclasses`.
@@ -408,6 +408,30 @@ These configurations are listed in the table below.
     </tr>
     <tr>
       <td>
+        <code>spec.image</code>
+      </td>
+      <td>
+      The RabbitMQ image reference.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>spec.imagePullSecret</code>
+      </td>
+      <td>
+Name of the Kubernetes secret for accessing the registry containing the RabbitMQ image. Only required for private registries.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>spec.service.type</code>
+      </td>
+      <td>
+      The Kubernetes Service type for the RabbitmqCluster Service. Must be ClusterIP, NodePort or LoadBalancer.
+      </td>
+    </tr>
+    <tr>
+      <td>
         <code>spec.service.annotations</code>
       </td>
       <td>
@@ -473,6 +497,9 @@ To update a RabbitMQ instance:
     ```
     kubectl describe statefulset definition-rabbitmq-server
     ```
+### Removing properties from the RabbitMQ instance
+
+It is possible to remove a property from a `RabbitmqCluster` object as part of an update. The property will revert to its default value if it has one. See [configurations](#configure) for default values.
 
 ## <a id='find'></a> Find Your RabbitmqCluster Service Name and Admin Credentials
 


### PR DESCRIPTION
## Changes:
Describing properties that are not configurable and have a default value. Describing the behaviour in the event that an attribute in `RabbitmqCluster` is deleted. Minor formatting changes and corrections.


### Should this be merged to any or all of the current released branches (i.e., for 0.7, 0.6, &/or 0.5)?
No need to merge into any released branch.

cc @ferozjilla 
