### PR TITLE
Add troubleshooting steps for Pods stuck in Terminating

### DIFF
--- a/troubleshooting.html.md.erb
+++ b/troubleshooting.html.md.erb
@@ -13,6 +13,7 @@ If you are responding to a specific error or error message, refer to the followi
 
 + [RabbitMQ Cluster Fails to Deploy](#failed-instance)
 + [Pods Are Not Being Created](#no-pods)
++ [Pods Are Stuck in Terminating State](#not-terminating-pods)
 
 
 <%= partial vars.path_to_partials + "/troubleshoot-template", locals: {
@@ -59,6 +60,23 @@ If you are responding to a specific error or error message, refer to the followi
   corresponding role-based access control (RBAC) resources.",
   solution: "Create the <code>PodSecurityPolicy</code> and RBAC resources by following the procedure in
   <a href='./using.html#psp'>Pod Security Policies</a>."
+} %>
+
+<%= partial vars.path_to_partials + "/troubleshoot-template", locals: {
+    id: "not-terminating-pods",
+    description: "Pods Are Stuck In Terminating State",
+    symptom: "After deleting a RabbitMQCluster instance, some Pods
+    are in Terminating state. RabbitMQ is still running in the affected Pods",
+    cause: "Common reasons for such failure is a Quorum Queue is left over in RabbitMQ",
+    solution: " To resolve this issue:
+          <br><br>
+          <ol>
+            <li>Ensure there are no messages left in the queue, or that is acceptable to
+            delete those messages.</li>
+            <li>Perform a 'force' delete using <code>kubectl delete pod --force POD-NAME</code>.
+            </li>
+          </ol>"
+
 } %>
 
 ## <a id='ts-install'></a> Troubleshoot the Installation

--- a/using.html.md.erb
+++ b/using.html.md.erb
@@ -667,3 +667,24 @@ To delete a service instance:
     $ kubectl delete -f definition.yaml
     rabbitmqcluster.rabbitmq.pivotal.io "definition" deleted
     </pre>
+
+If you had created any number [quorum queues](https://www.rabbitmq.com/quorum-queues.html) in RabbitMQ, the Pods
+might block/halt the termination process due to a safety mechanism to prevent data loss. In this case, the Pods
+will be in a terminating state, but RabbitMQ will not receive a shutdown signal.
+
+In this situation, it is recommended to forcibly delete the remaining Pods using the `kubectl delete pod --force` command.
+In the following example, `INSTANCE` is `rabbit-rollout-restart`:
+
+```bash
+kubectl -n pivotal-rabbitmq-system get all
+  NAME                                           READY   STATUS        RESTARTS   AGE
+  pod/rabbit-rollout-restart-rabbitmq-server-0   1/1     Terminating   0          30h
+  pod/rabbit-rollout-restart-rabbitmq-server-1   1/1     Terminating   0          30h
+
+kubectl delete pod --force --grace-period=0 -l 'app.kubernetes.io/name=rabbit-rollout-restart'
+  warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.
+  pod "rabbit-rollout-restart-rabbitmq-server-0" force deleted
+  pod "rabbit-rollout-restart-rabbitmq-server-1" force deleted
+```
+
+This behaviour will be improved in a future release to remove the Pods gracefully when a RabbitMQ instance is deleted.


### PR DESCRIPTION
## Changes:
- Add explanation regarding Pods stuck in terminating state
- Add command and example to delete Pods stuck in terminating state
- Add a section in troubleshooting for Pods stuck in terminating state

### Should this be merged to any or all of the current released branches (i.e., for 0.7, 0.6, &/or 0.5)?
This should go to the latest release branch.

Related to https://github.com/pivotal/rabbitmq-for-kubernetes/issues/48