### PR TITLE
Add downardAPI to example policy for Pod deletion

### DIFF
--- a/examples-annex.html.md.erb
+++ b/examples-annex.html.md.erb
@@ -113,6 +113,7 @@ spec:
   - configMap
   - persistentVolumeClaim
   - emptyDir
+  - downwardAPI
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
We use the DownwardAPI in our cluster finalizer deletion strategy

## Changes:



### Should this be merged to any or all of the current released branches (i.e., for 0.7, 0.6, &/or 0.5)?
(0.4 is no longer maintained.)

This is change is only applicable to the 0.8 release an onwards
