### PR TITLE
clarify version required for the operator.yaml

### DIFF
--- a/installing-with-kubectl.html.md.erb
+++ b/installing-with-kubectl.html.md.erb
@@ -129,11 +129,11 @@ To authorize access to images:
 To configure the image registry:
 
 1. Edit `manifests/operator.yaml`.
-1. Replace all instances of `REPLACE-WITH-OPERATOR-IMAGE-URL` with the full Kubernetes Operator image reference.
+1. Replace all instances of `REPLACE-WITH-OPERATOR-IMAGE-URL` with the full Kubernetes Operator image reference and explicit version.
 This reference should look similar to the below:
 
     ```
-    image: YOUR-REGISTRY/rabbitmq-for-kubernetes-operator:$version
+    image: YOUR-REGISTRY/rabbitmq-for-kubernetes-operator:YOUR-VERSION
     ```
 
 ## <a id='deploy-op'></a> Install <%= vars.product_short %>


### PR DESCRIPTION
My workstation did not replace $version in the operator.yaml file. It was really hard to figure out that I needed to explicitly add the version tag on my repo. After I updated my operator.yaml file, everything worked!

## Changes:



### Should this be merged to any or all of the current released branches (i.e., for 0.7, 0.6, &/or 0.5)?
(0.4 is no longer maintained.)
